### PR TITLE
Update ChartData to use Rails builtin hash transformation methods

### DIFF
--- a/app/models/chart_data.rb
+++ b/app/models/chart_data.rb
@@ -8,7 +8,7 @@ class ChartData
   end
 
   def pagevisits_count_per_month
-    Hash[pagevisit_by_month.map {|m, p| [m, p.count] }]
+    pagevisit_by_month.transform_values { |p| p.count }
   end
 
   def densify
@@ -23,7 +23,7 @@ class ChartData
   end
 
   def labeled_frequency_data
-    Hash[sorted_densified.map {|m, p| [Date::MONTHNAMES[m], p] }]
+    sorted_densified.transform_keys { |m| Date::MONTHNAMES[m] }
   end
 
 end


### PR DESCRIPTION
I knew I'd seen these methods somewhere recently:

[`Hash#transform_keys`](http://api.rubyonrails.org/classes/Hash.html#method-i-transform_keys) and [`Hash#transform_values`](http://api.rubyonrails.org/classes/Hash.html#method-i-transform_values) are [Rails extensions](http://edgeguides.rubyonrails.org/active_support_core_extensions.html#extensions-to-hash) to the core `Hash` class that implement these common idioms, and were introduced in the [`4.2`](http://guides.rubyonrails.org/4_2_release_notes.html#notable-changes) release a couple months ago.
